### PR TITLE
Fix Express config to support Room URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ async function launch() {
 
     if (process.env.NODE_ENV === "production") {
         app.use(express.static(path.join(__dirname, 'build')));
-        app.get('/', function(req, res) {
+        app.get('/*', function(req, res) {
             res.sendFile(path.join(__dirname, 'build', 'index.html'));
         });
     }


### PR DESCRIPTION
Room URLs did not work properly because the Express server was not set up properly (accepting only `/` as a route instead of `/*` to serve our client).